### PR TITLE
Added new parameter selectedYearTextStyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ var results = await showCalendarDatePicker2Dialog(
 | disabledDayTextStyle      | TextStyle?               | Custom text style for disabled calendar day(s)                                      |
 | todayTextStyle            | TextStyle?               | Custom text style for current calendar day                                          |
 | yearTextStyle             | TextStyle?               | Custom text style for years list                                                    |
+| selectedYearTextStyle     | TextStyle?               | Custom text style for selected year                                                 |
 | dayBorderRadius           | BorderRadius?            | Custom border radius for day indicator                                              |
 | yearBorderRadius          | BorderRadius?            | Custom border radius for year indicator                                             |
 

--- a/lib/src/models/calendar_date_picker2_config.dart
+++ b/lib/src/models/calendar_date_picker2_config.dart
@@ -22,6 +22,7 @@ class CalendarDatePicker2Config {
     this.disabledDayTextStyle,
     this.todayTextStyle,
     this.yearTextStyle,
+    this.selectedYearTextStyle,
     this.dayBorderRadius,
     this.yearBorderRadius,
   })  : calendarType = calendarType ?? CalendarDatePicker2Type.single,
@@ -89,6 +90,9 @@ class CalendarDatePicker2Config {
   // Custom text style for years list
   final TextStyle? yearTextStyle;
 
+  // Custom text style for selected year
+  final TextStyle? selectedYearTextStyle;
+
   /// Custom border radius for day indicator
   final BorderRadius? dayBorderRadius;
 
@@ -114,6 +118,7 @@ class CalendarDatePicker2Config {
     TextStyle? disabledDayTextStyle,
     TextStyle? todayTextStyle,
     TextStyle? yearTextStyle,
+    TextStyle? selectedYearTextStyle,
     BorderRadius? dayBorderRadius,
     BorderRadius? yearBorderRadius,
   }) {
@@ -124,8 +129,7 @@ class CalendarDatePicker2Config {
       currentDate: currentDate ?? this.currentDate,
       calendarViewMode: calendarViewMode ?? this.calendarViewMode,
       weekdayLabels: weekdayLabels ?? this.weekdayLabels,
-      weekdayLabelTextStyle:
-          weekdayLabelTextStyle ?? this.weekdayLabelTextStyle,
+      weekdayLabelTextStyle: weekdayLabelTextStyle ?? this.weekdayLabelTextStyle,
       firstDayOfWeek: firstDayOfWeek ?? this.firstDayOfWeek,
       controlsHeight: controlsHeight ?? this.controlsHeight,
       lastMonthIcon: lastMonthIcon ?? this.lastMonthIcon,
@@ -133,19 +137,18 @@ class CalendarDatePicker2Config {
       controlsTextStyle: controlsTextStyle ?? this.controlsTextStyle,
       dayTextStyle: dayTextStyle ?? this.dayTextStyle,
       selectedDayTextStyle: selectedDayTextStyle ?? this.selectedDayTextStyle,
-      selectedDayHighlightColor:
-          selectedDayHighlightColor ?? this.selectedDayHighlightColor,
+      selectedDayHighlightColor: selectedDayHighlightColor ?? this.selectedDayHighlightColor,
       disabledDayTextStyle: disabledDayTextStyle ?? this.disabledDayTextStyle,
       todayTextStyle: todayTextStyle ?? this.todayTextStyle,
       yearTextStyle: yearTextStyle ?? this.yearTextStyle,
+      selectedYearTextStyle: selectedYearTextStyle ?? this.selectedYearTextStyle,
       dayBorderRadius: dayBorderRadius ?? this.dayBorderRadius,
       yearBorderRadius: yearBorderRadius ?? this.yearBorderRadius,
     );
   }
 }
 
-class CalendarDatePicker2WithActionButtonsConfig
-    extends CalendarDatePicker2Config {
+class CalendarDatePicker2WithActionButtonsConfig extends CalendarDatePicker2Config {
   CalendarDatePicker2WithActionButtonsConfig({
     CalendarDatePicker2Type? calendarType,
     DateTime? firstDate,
@@ -165,6 +168,7 @@ class CalendarDatePicker2WithActionButtonsConfig
     TextStyle? disabledDayTextStyle,
     TextStyle? todayTextStyle,
     TextStyle? yearTextStyle,
+    TextStyle? selectedYearTextStyle,
     BorderRadius? dayBorderRadius,
     BorderRadius? yearBorderRadius,
     this.gapBetweenCalendarAndButtons,
@@ -194,6 +198,7 @@ class CalendarDatePicker2WithActionButtonsConfig
           disabledDayTextStyle: disabledDayTextStyle,
           todayTextStyle: todayTextStyle,
           yearTextStyle: yearTextStyle,
+          selectedYearTextStyle: selectedYearTextStyle,
           dayBorderRadius: dayBorderRadius,
           yearBorderRadius: yearBorderRadius,
         );
@@ -242,6 +247,7 @@ class CalendarDatePicker2WithActionButtonsConfig
     TextStyle? disabledDayTextStyle,
     TextStyle? todayTextStyle,
     TextStyle? yearTextStyle,
+    TextStyle? selectedYearTextStyle,
     double? gapBetweenCalendarAndButtons,
     TextStyle? cancelButtonTextStyle,
     Widget? cancelButton,
@@ -260,8 +266,7 @@ class CalendarDatePicker2WithActionButtonsConfig
       currentDate: currentDate ?? this.currentDate,
       calendarViewMode: calendarViewMode ?? this.calendarViewMode,
       weekdayLabels: weekdayLabels ?? this.weekdayLabels,
-      weekdayLabelTextStyle:
-          weekdayLabelTextStyle ?? this.weekdayLabelTextStyle,
+      weekdayLabelTextStyle: weekdayLabelTextStyle ?? this.weekdayLabelTextStyle,
       firstDayOfWeek: firstDayOfWeek ?? this.firstDayOfWeek,
       controlsHeight: controlsHeight ?? this.controlsHeight,
       lastMonthIcon: lastMonthIcon ?? this.lastMonthIcon,
@@ -269,23 +274,20 @@ class CalendarDatePicker2WithActionButtonsConfig
       controlsTextStyle: controlsTextStyle ?? this.controlsTextStyle,
       dayTextStyle: dayTextStyle ?? this.dayTextStyle,
       selectedDayTextStyle: selectedDayTextStyle ?? this.selectedDayTextStyle,
-      selectedDayHighlightColor:
-          selectedDayHighlightColor ?? this.selectedDayHighlightColor,
+      selectedDayHighlightColor: selectedDayHighlightColor ?? this.selectedDayHighlightColor,
       disabledDayTextStyle: disabledDayTextStyle ?? this.disabledDayTextStyle,
       todayTextStyle: todayTextStyle ?? this.todayTextStyle,
       yearTextStyle: yearTextStyle ?? this.yearTextStyle,
+      selectedYearTextStyle: selectedYearTextStyle ?? this.selectedYearTextStyle,
       gapBetweenCalendarAndButtons:
           gapBetweenCalendarAndButtons ?? this.gapBetweenCalendarAndButtons,
-      cancelButtonTextStyle:
-          cancelButtonTextStyle ?? this.cancelButtonTextStyle,
+      cancelButtonTextStyle: cancelButtonTextStyle ?? this.cancelButtonTextStyle,
       cancelButton: cancelButton ?? this.cancelButton,
       okButtonTextStyle: okButtonTextStyle ?? this.okButtonTextStyle,
       okButton: okButton ?? this.okButton,
       openedFromDialog: openedFromDialog ?? this.openedFromDialog,
-      closeDialogOnCancelTapped:
-          closeDialogOnCancelTapped ?? this.closeDialogOnCancelTapped,
-      closeDialogOnOkTapped:
-          closeDialogOnOkTapped ?? this.closeDialogOnOkTapped,
+      closeDialogOnCancelTapped: closeDialogOnCancelTapped ?? this.closeDialogOnCancelTapped,
+      closeDialogOnOkTapped: closeDialogOnOkTapped ?? this.closeDialogOnOkTapped,
       dayBorderRadius: dayBorderRadius ?? this.dayBorderRadius,
       yearBorderRadius: yearBorderRadius ?? this.yearBorderRadius,
     );

--- a/lib/src/widgets/calendar_date_picker2.dart
+++ b/lib/src/widgets/calendar_date_picker2.dart
@@ -1297,7 +1297,8 @@ class _YearPickerState extends State<YearPicker> {
     } else {
       textColor = colorScheme.onSurface.withOpacity(0.87);
     }
-    TextStyle? itemStyle = (widget.config.yearTextStyle ?? textTheme.bodyText1)?.apply(color: textColor);
+    TextStyle? itemStyle = widget.config.yearTextStyle ??
+        textTheme.bodyText1?.apply(color: textColor);
     if (isSelected){
       itemStyle = widget.config.selectedYearTextStyle ?? itemStyle;
     }

--- a/lib/src/widgets/calendar_date_picker2.dart
+++ b/lib/src/widgets/calendar_date_picker2.dart
@@ -1297,15 +1297,10 @@ class _YearPickerState extends State<YearPicker> {
     } else {
       textColor = colorScheme.onSurface.withOpacity(0.87);
     }
-    TextStyle? itemStyle = textTheme.bodyText1;
-
-    if (isSelected && widget.config.selectedYearTextStyle != null){
-      itemStyle =  widget.config.selectedYearTextStyle;
-    } else {
-      itemStyle = widget.config.yearTextStyle ?? textTheme.bodyText1;
+    TextStyle? itemStyle = (widget.config.yearTextStyle ?? textTheme.bodyText1)?.apply(color: textColor);
+    if (isSelected){
+      itemStyle = widget.config.selectedYearTextStyle ?? itemStyle;
     }
-
-    itemStyle = itemStyle?.apply(color: textColor);
 
     BoxDecoration? decoration;
     if (isSelected) {

--- a/lib/src/widgets/calendar_date_picker2.dart
+++ b/lib/src/widgets/calendar_date_picker2.dart
@@ -1297,7 +1297,15 @@ class _YearPickerState extends State<YearPicker> {
     } else {
       textColor = colorScheme.onSurface.withOpacity(0.87);
     }
-    final TextStyle? itemStyle = textTheme.bodyText1?.apply(color: textColor);
+    TextStyle? itemStyle = textTheme.bodyText1;
+
+    if (isSelected && widget.config.selectedYearTextStyle != null){
+      itemStyle =  widget.config.selectedYearTextStyle;
+    } else {
+      itemStyle = widget.config.yearTextStyle ?? textTheme.bodyText1;
+    }
+
+    itemStyle = itemStyle?.apply(color: textColor);
 
     BoxDecoration? decoration;
     if (isSelected) {
@@ -1327,7 +1335,7 @@ class _YearPickerState extends State<YearPicker> {
             button: true,
             child: Text(
               year.toString(),
-              style: widget.config.yearTextStyle ?? itemStyle,
+              style: itemStyle,
             ),
           ),
         ),


### PR DESCRIPTION
Enhancement for selectedYearTextStyle.

Reason: Previously it was not possible to change the text style of the selected year, so it looked inconsistent if using a custom selectedDayTextStyle.

Added new parameter selectedYearTextStyle and implemented it into calendar_date_picker2.dart, updated Readme.md