### PR TITLE
feat: allow changing highlight color of days included in range

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ var results = await showCalendarDatePicker2Dialog(
 | controlsTextStyle           | TextStyle?                     | Custom text style for calendar mode toggle control                                  |
 | dayTextStyle                | TextStyle?                     | Custom text style for calendar day text                                             |
 | selectedDayTextStyle        | TextStyle?                     | Custom text style for selected calendar day text                                    |
-| selectedDayHighlightColor   | Color?                         | The highlight color for the selected day                                                    |
-| selectedRangeHighlightColor | Color?                         | The highlight color for days included in the selected range  |
+| selectedDayHighlightColor   | Color?                         | The highlight color for selected day(s)                                                    |
+| selectedRangeHighlightColor | Color?                         | The highlight color for day(s) included in the selected range  |
 | disabledDayTextStyle        | TextStyle?                     | Custom text style for disabled calendar day(s)                                      |
 | todayTextStyle              | TextStyle?                     | Custom text style for current calendar day                                          |
 | yearTextStyle               | TextStyle?                     | Custom text style for years list                                                    |

--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ var results = await showCalendarDatePicker2Dialog(
 | controlsTextStyle           | TextStyle?                     | Custom text style for calendar mode toggle control                                  |
 | dayTextStyle                | TextStyle?                     | Custom text style for calendar day text                                             |
 | selectedDayTextStyle        | TextStyle?                     | Custom text style for selected calendar day text                                    |
-| selectedDayHighlightColor   | Color?                         | The highlight color selected day                                                    |
+| selectedDayHighlightColor   | Color?                         | The highlight color for the selected day                                                    |
+| selectedRangeHighlightColor | Color?                         | The highlight color for days included in the selected range  |
 | disabledDayTextStyle        | TextStyle?                     | Custom text style for disabled calendar day(s)                                      |
 | todayTextStyle              | TextStyle?                     | Custom text style for current calendar day                                          |
 | yearTextStyle               | TextStyle?                     | Custom text style for years list                                                    |

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -205,5 +205,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=2.18.0 <4.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=1.17.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -205,5 +205,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=2.18.0 <4.0.0"
   flutter: ">=1.17.0"

--- a/lib/src/models/calendar_date_picker2_config.dart
+++ b/lib/src/models/calendar_date_picker2_config.dart
@@ -32,6 +32,7 @@ class CalendarDatePicker2Config {
     this.dayTextStyle,
     this.selectedDayTextStyle,
     this.selectedDayHighlightColor,
+    this.selectedRangeIncludedDayColor,
     this.disabledDayTextStyle,
     this.todayTextStyle,
     this.yearTextStyle,
@@ -99,6 +100,10 @@ class CalendarDatePicker2Config {
 
   /// The highlight color for selected day(s)
   final Color? selectedDayHighlightColor;
+
+  /// The highlight color for day(s) included in the selected range
+  /// Only applicable when [calendarType] is [CalendarDatePicker2Type.range]
+  final Color? selectedRangeIncludedDayColor;
 
   /// Custom text style for disabled calendar day(s)
   final TextStyle? disabledDayTextStyle;

--- a/lib/src/models/calendar_date_picker2_config.dart
+++ b/lib/src/models/calendar_date_picker2_config.dart
@@ -32,7 +32,7 @@ class CalendarDatePicker2Config {
     this.dayTextStyle,
     this.selectedDayTextStyle,
     this.selectedDayHighlightColor,
-    this.selectedRangeIncludedDayColor,
+    this.selectedRangeHighlightColor,
     this.disabledDayTextStyle,
     this.todayTextStyle,
     this.yearTextStyle,
@@ -103,7 +103,7 @@ class CalendarDatePicker2Config {
 
   /// The highlight color for day(s) included in the selected range
   /// Only applicable when [calendarType] is [CalendarDatePicker2Type.range]
-  final Color? selectedRangeIncludedDayColor;
+  final Color? selectedRangeHighlightColor;
 
   /// Custom text style for disabled calendar day(s)
   final TextStyle? disabledDayTextStyle;

--- a/lib/src/widgets/calendar_date_picker2.dart
+++ b/lib/src/widgets/calendar_date_picker2.dart
@@ -1090,7 +1090,7 @@ class _DayPickerState extends State<_DayPicker> {
 
             if (isDateInRange && !isStartDateSameToEndDate) {
               final rangePickerIncludedDayDecoration = BoxDecoration(
-                color: widget.config.selectedRangeIncludedDayColor ??
+                color: widget.config.selectedRangeHighlightColor ??
                     (widget.config.selectedDayHighlightColor ??
                             selectedDayBackground)
                         .withOpacity(0.15),

--- a/lib/src/widgets/calendar_date_picker2.dart
+++ b/lib/src/widgets/calendar_date_picker2.dart
@@ -1090,9 +1090,10 @@ class _DayPickerState extends State<_DayPicker> {
 
             if (isDateInRange && !isStartDateSameToEndDate) {
               final rangePickerIncludedDayDecoration = BoxDecoration(
-                color: (widget.config.selectedDayHighlightColor ??
-                        selectedDayBackground)
-                    .withOpacity(0.15),
+                color: widget.config.selectedRangeIncludedDayColor ??
+                    (widget.config.selectedDayHighlightColor ??
+                            selectedDayBackground)
+                        .withOpacity(0.15),
               );
 
               if (DateUtils.isSameDay(startDate, dayToBuild)) {


### PR DESCRIPTION
When working with this library on a dark background, the range highlight color is hard to see. The changes below add a new config option to be able to customize this.