### PR TITLE
fixed border radius on a dialog

### DIFF
--- a/lib/src/utils/dialog.dart
+++ b/lib/src/utils/dialog.dart
@@ -20,23 +20,22 @@ Future<List<DateTime?>?> showCalendarDatePicker2Dialog({
 }) {
   var dialog = Dialog(
     insetPadding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0),
-    backgroundColor: Colors.transparent,
-    clipBehavior: Clip.antiAlias,
-    child: Material(
-      color: dialogBackgroundColor ?? Theme.of(context).canvasColor,
+    backgroundColor: dialogBackgroundColor ?? Theme.of(context).canvasColor,
+    shape: RoundedRectangleBorder(
       borderRadius: borderRadius ?? BorderRadius.circular(10),
-      child: SizedBox(
-        width: dialogSize.width,
-        height: max(dialogSize.height, 410),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            CalendarDatePicker2WithActionButtons(
-              initialValue: initialValue,
-              config: config.copyWith(openedFromDialog: true),
-            ),
-          ],
-        ),
+    ),
+    clipBehavior: Clip.antiAlias,
+    child: SizedBox(
+      width: dialogSize.width,
+      height: max(dialogSize.height, 410),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          CalendarDatePicker2WithActionButtons(
+            initialValue: initialValue,
+            config: config.copyWith(openedFromDialog: true),
+          ),
+        ],
       ),
     ),
   );

--- a/lib/src/widgets/calendar_date_picker2_with_action_buttons.dart
+++ b/lib/src/widgets/calendar_date_picker2_with_action_buttons.dart
@@ -9,6 +9,8 @@ class CalendarDatePicker2WithActionButtons extends StatefulWidget {
     this.onDisplayedMonthChanged,
     this.onCancelTapped,
     this.onOkTapped,
+    this.confirmText,
+    this.cancelText,
     Key? key,
   }) : super(key: key);
 
@@ -22,6 +24,12 @@ class CalendarDatePicker2WithActionButtons extends StatefulWidget {
 
   /// The calendar configurations including action buttons
   final CalendarDatePicker2WithActionButtonsConfig config;
+
+  /// The text that is displayed on the cancel button.
+  final String? cancelText;
+
+  /// The text that is displayed on the confirm button.
+  final String? confirmText;
 
   /// The callback when cancel button is tapped
   final Function? onCancelTapped;
@@ -75,6 +83,8 @@ class _CalendarDatePicker2WithActionButtonsState
 
   @override
   Widget build(BuildContext context) {
+    final MaterialLocalizations localizations =
+        MaterialLocalizations.of(context);
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -91,17 +101,18 @@ class _CalendarDatePicker2WithActionButtonsState
         Row(
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
-            _buildCancelButton(Theme.of(context).colorScheme),
+            _buildCancelButton(Theme.of(context).colorScheme, localizations),
             if ((widget.config.gapBetweenCalendarAndButtons ?? 0) > 0)
               SizedBox(width: widget.config.gapBetweenCalendarAndButtons),
-            _buildOkButton(Theme.of(context).colorScheme),
+            _buildOkButton(Theme.of(context).colorScheme, localizations),
           ],
         ),
       ],
     );
   }
 
-  Widget _buildCancelButton(ColorScheme colorScheme) {
+  Widget _buildCancelButton(
+      ColorScheme colorScheme, MaterialLocalizations localizations) {
     return InkWell(
       borderRadius: BorderRadius.circular(5),
       onTap: () => setState(() {
@@ -117,7 +128,9 @@ class _CalendarDatePicker2WithActionButtonsState
             const EdgeInsets.symmetric(vertical: 10, horizontal: 15),
         child: widget.config.cancelButton ??
             Text(
-              'CANCEL',
+              Theme.of(context).useMaterial3
+                  ? localizations.cancelButtonLabel
+                  : localizations.cancelButtonLabel.toUpperCase(),
               style: widget.config.cancelButtonTextStyle ??
                   TextStyle(
                     color: widget.config.selectedDayHighlightColor ??
@@ -130,7 +143,8 @@ class _CalendarDatePicker2WithActionButtonsState
     );
   }
 
-  Widget _buildOkButton(ColorScheme colorScheme) {
+  Widget _buildOkButton(
+      ColorScheme colorScheme, MaterialLocalizations localizations) {
     return InkWell(
       borderRadius: BorderRadius.circular(5),
       onTap: () => setState(() {
@@ -147,7 +161,7 @@ class _CalendarDatePicker2WithActionButtonsState
             const EdgeInsets.symmetric(vertical: 10, horizontal: 15),
         child: widget.config.okButton ??
             Text(
-              'OK',
+              localizations.okButtonLabel,
               style: widget.config.okButtonTextStyle ??
                   TextStyle(
                     color: widget.config.selectedDayHighlightColor ??


### PR DESCRIPTION
Hi!
This PR fixes the border radius when using showCalendarDatePicker2Dialog(). Previously, it was not working with small radius values, so there was no way to make a dialog with a rectangular shape for example