### PR TITLE
Fixes unmodified list error when `initialList` is a constant list.

### DIFF
--- a/lib/src/widgets/calendar_date_picker2.dart
+++ b/lib/src/widgets/calendar_date_picker2.dart
@@ -96,7 +96,7 @@ class _CalendarDatePicker2State extends State<CalendarDatePicker2> {
         : DateUtils.dateOnly(DateTime.now());
     _mode = config.calendarViewMode;
     _currentDisplayedMonthDate = DateTime(initialDate.year, initialDate.month);
-    _selectedDates = widget.initialValue.toList();
+    _selectedDates = widget.initialValue;
   }
 
   @override
@@ -105,7 +105,7 @@ class _CalendarDatePicker2State extends State<CalendarDatePicker2> {
     if (widget.config.calendarViewMode != oldWidget.config.calendarViewMode) {
       _mode = widget.config.calendarViewMode;
     }
-    _selectedDates = widget.initialValue.toList();
+    _selectedDates = widget.initialValue;
   }
 
   @override

--- a/lib/src/widgets/calendar_date_picker2.dart
+++ b/lib/src/widgets/calendar_date_picker2.dart
@@ -96,7 +96,7 @@ class _CalendarDatePicker2State extends State<CalendarDatePicker2> {
         : DateUtils.dateOnly(DateTime.now());
     _mode = config.calendarViewMode;
     _currentDisplayedMonthDate = DateTime(initialDate.year, initialDate.month);
-    _selectedDates = widget.initialValue;
+    _selectedDates = widget.initialValue.toList();
   }
 
   @override
@@ -105,7 +105,7 @@ class _CalendarDatePicker2State extends State<CalendarDatePicker2> {
     if (widget.config.calendarViewMode != oldWidget.config.calendarViewMode) {
       _mode = widget.config.calendarViewMode;
     }
-    _selectedDates = widget.initialValue;
+    _selectedDates = widget.initialValue.toList();
   }
 
   @override

--- a/test/calendar_date_picker2_test.dart
+++ b/test/calendar_date_picker2_test.dart
@@ -1,5 +1,16 @@
+import 'package:calendar_date_picker2/calendar_date_picker2.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('Calendar date picker2 unit test', () {});
+  testWidgets('Empty initial list wont throw unmodified list',
+      (widgetTester) async {
+    await widgetTester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: CalendarDatePicker2(
+            initialValue: const [], config: CalendarDatePicker2Config()),
+      ),
+    ));
+  });
 }

--- a/test/calendar_date_picker2_test.dart
+++ b/test/calendar_date_picker2_test.dart
@@ -4,12 +4,13 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('Calendar date picker2 unit test', () {});
-  testWidgets('Empty initial list wont throw unmodified list',
+  testWidgets('Constant initial list wont throw unmodified list',
       (widgetTester) async {
+    const emp = <DateTime>[];
     await widgetTester.pumpWidget(MaterialApp(
       home: Scaffold(
         body: CalendarDatePicker2(
-            initialValue: const [], config: CalendarDatePicker2Config()),
+            initialValue: emp, config: CalendarDatePicker2Config()),
       ),
     ));
   });


### PR DESCRIPTION
When the given parameter for `intialList` is a constant value, it cannot be modified thus it will throw and error when trying to modify it. This is fixed by getting applying a "soft copy" of the list instead of directly assigning it internally. A test is also added to prevent regression.