### PR TITLE
Added Opacity for highlight color

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ var results = await showCalendarDatePicker2Dialog(
 | dayTextStyle              | TextStyle?                     | Custom text style for calendar day text                                             |
 | selectedDayTextStyle      | TextStyle?                     | Custom text style for selected calendar day text                                    |
 | selectedDayHighlightColor | Color?                         | The highlight color selected day                                                    |
-| selectedDayHighlightOpacity | double?                        | The highlight color opacity (This will affect only range selection)                 |
+| selectedRangeHighlightColor | Color?                        | The highlight color for day(s) included in the selected range                       |
 | disabledDayTextStyle      | TextStyle?                     | Custom text style for disabled calendar day(s)                                      |
 | todayTextStyle            | TextStyle?                     | Custom text style for current calendar day                                          |
 | yearTextStyle             | TextStyle?                     | Custom text style for years list                                                    |

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ var results = await showCalendarDatePicker2Dialog(
 ### For CalendarDatePicker2Config:
 
 | Option                    | Type                           | Description                                                                         |
-| ------------------------- | ------------------------------ | ----------------------------------------------------------------------------------- |
+| ------------------------- |--------------------------------|-------------------------------------------------------------------------------------|
 | calendarType              | CalendarDatePicker2Type?       | Calendar picker type, has 3 values: single, multi, range                            |
 | firstDate                 | DateTime?                      | The earliest allowable DateTime user can select                                     |
 | lastDate                  | DateTime?                      | The latest allowable DateTime user can select                                       |
@@ -126,6 +126,7 @@ var results = await showCalendarDatePicker2Dialog(
 | dayTextStyle              | TextStyle?                     | Custom text style for calendar day text                                             |
 | selectedDayTextStyle      | TextStyle?                     | Custom text style for selected calendar day text                                    |
 | selectedDayHighlightColor | Color?                         | The highlight color selected day                                                    |
+| selectedDayHighlightOpacity | double?                        | The highlight color opacity (This will affect only range selection)                 |
 | disabledDayTextStyle      | TextStyle?                     | Custom text style for disabled calendar day(s)                                      |
 | todayTextStyle            | TextStyle?                     | Custom text style for current calendar day                                          |
 | yearTextStyle             | TextStyle?                     | Custom text style for years list                                                    |

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,16 +5,14 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.1"
   calendar_date_picker2:
@@ -28,40 +26,35 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.17.0"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: "1989d917fbe8e6b39806207df5a3fdd3d816cbd090fac2ce26fb45e9a71476e5"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.1"
   flutter:
@@ -73,8 +66,7 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
   flutter_localizations:
@@ -91,56 +83,42 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: "910f85bce16fb5c6f614e117efa303e85a1731bb0081edf3604a2ae6e9a3cc91"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.17.0"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.5"
   lints:
     dependency: transitive
     description:
       name: lints
-      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.2"
   sky_engine:
@@ -152,56 +130,49 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.16"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
-      url: "https://pub.dev"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.4"
 sdks:

--- a/lib/src/models/calendar_date_picker2_config.dart
+++ b/lib/src/models/calendar_date_picker2_config.dart
@@ -45,7 +45,7 @@ class CalendarDatePicker2Config {
     this.dayTextStyle,
     this.selectedDayTextStyle,
     this.selectedDayHighlightColor,
-    this.selectedDayHighlightOpacity,
+    this.selectedRangeHighlightColor,
     this.disabledDayTextStyle,
     this.todayTextStyle,
     this.yearTextStyle,
@@ -117,8 +117,9 @@ class CalendarDatePicker2Config {
   /// The highlight color for selected day(s)
   final Color? selectedDayHighlightColor;
 
-  /// The highlight color Opacity. Default value is 0.15
-  final double? selectedDayHighlightOpacity;
+  /// The highlight color for day(s) included in the selected range
+  /// Only applicable when [calendarType] is [CalendarDatePicker2Type.range]
+  final Color? selectedRangeHighlightColor;
 
   /// Custom text style for disabled calendar day(s)
   final TextStyle? disabledDayTextStyle;
@@ -178,7 +179,7 @@ class CalendarDatePicker2Config {
     TextStyle? dayTextStyle,
     TextStyle? selectedDayTextStyle,
     Color? selectedDayHighlightColor,
-    double? selectedDayHighlightOpacity,
+    Color? selectedRangeHighlightColor,
     TextStyle? disabledDayTextStyle,
     TextStyle? todayTextStyle,
     TextStyle? yearTextStyle,
@@ -212,8 +213,8 @@ class CalendarDatePicker2Config {
       selectedDayTextStyle: selectedDayTextStyle ?? this.selectedDayTextStyle,
       selectedDayHighlightColor:
           selectedDayHighlightColor ?? this.selectedDayHighlightColor,
-      selectedDayHighlightOpacity:
-          selectedDayHighlightOpacity ?? this.selectedDayHighlightOpacity,
+      selectedRangeHighlightColor:
+          selectedRangeHighlightColor ?? this.selectedRangeHighlightColor,
       disabledDayTextStyle: disabledDayTextStyle ?? this.disabledDayTextStyle,
       todayTextStyle: todayTextStyle ?? this.todayTextStyle,
       yearTextStyle: yearTextStyle ?? this.yearTextStyle,
@@ -255,7 +256,7 @@ class CalendarDatePicker2WithActionButtonsConfig
     TextStyle? dayTextStyle,
     TextStyle? selectedDayTextStyle,
     Color? selectedDayHighlightColor,
-    double? selectedDayHighlightOpacity,
+    Color? selectedRangeHighlightColor,
     TextStyle? disabledDayTextStyle,
     TextStyle? todayTextStyle,
     TextStyle? yearTextStyle,
@@ -295,7 +296,7 @@ class CalendarDatePicker2WithActionButtonsConfig
           dayTextStyle: dayTextStyle,
           selectedDayTextStyle: selectedDayTextStyle,
           selectedDayHighlightColor: selectedDayHighlightColor,
-          selectedDayHighlightOpacity: selectedDayHighlightOpacity,
+          selectedRangeHighlightColor: selectedRangeHighlightColor,
           disabledDayTextStyle: disabledDayTextStyle,
           todayTextStyle: todayTextStyle,
           yearTextStyle: yearTextStyle,
@@ -356,7 +357,7 @@ class CalendarDatePicker2WithActionButtonsConfig
     TextStyle? dayTextStyle,
     TextStyle? selectedDayTextStyle,
     Color? selectedDayHighlightColor,
-    double? selectedDayHighlightOpacity,
+    Color? selectedRangeHighlightColor,
     TextStyle? disabledDayTextStyle,
     TextStyle? todayTextStyle,
     TextStyle? yearTextStyle,
@@ -399,8 +400,8 @@ class CalendarDatePicker2WithActionButtonsConfig
       selectedDayTextStyle: selectedDayTextStyle ?? this.selectedDayTextStyle,
       selectedDayHighlightColor:
           selectedDayHighlightColor ?? this.selectedDayHighlightColor,
-      selectedDayHighlightOpacity:
-          selectedDayHighlightOpacity ?? this.selectedDayHighlightOpacity,
+      selectedRangeHighlightColor:
+          selectedRangeHighlightColor ?? this.selectedRangeHighlightColor,
       disabledDayTextStyle: disabledDayTextStyle ?? this.disabledDayTextStyle,
       todayTextStyle: todayTextStyle ?? this.todayTextStyle,
       yearTextStyle: yearTextStyle ?? this.yearTextStyle,

--- a/lib/src/models/calendar_date_picker2_config.dart
+++ b/lib/src/models/calendar_date_picker2_config.dart
@@ -45,6 +45,7 @@ class CalendarDatePicker2Config {
     this.dayTextStyle,
     this.selectedDayTextStyle,
     this.selectedDayHighlightColor,
+    this.selectedDayHighlightOpacity,
     this.disabledDayTextStyle,
     this.todayTextStyle,
     this.yearTextStyle,
@@ -116,6 +117,9 @@ class CalendarDatePicker2Config {
   /// The highlight color for selected day(s)
   final Color? selectedDayHighlightColor;
 
+  /// The highlight color Opacity. Default value is 0.15
+  final double? selectedDayHighlightOpacity;
+
   /// Custom text style for disabled calendar day(s)
   final TextStyle? disabledDayTextStyle;
 
@@ -174,6 +178,7 @@ class CalendarDatePicker2Config {
     TextStyle? dayTextStyle,
     TextStyle? selectedDayTextStyle,
     Color? selectedDayHighlightColor,
+    double? selectedDayHighlightOpacity,
     TextStyle? disabledDayTextStyle,
     TextStyle? todayTextStyle,
     TextStyle? yearTextStyle,
@@ -207,6 +212,8 @@ class CalendarDatePicker2Config {
       selectedDayTextStyle: selectedDayTextStyle ?? this.selectedDayTextStyle,
       selectedDayHighlightColor:
           selectedDayHighlightColor ?? this.selectedDayHighlightColor,
+      selectedDayHighlightOpacity:
+          selectedDayHighlightOpacity ?? this.selectedDayHighlightOpacity,
       disabledDayTextStyle: disabledDayTextStyle ?? this.disabledDayTextStyle,
       todayTextStyle: todayTextStyle ?? this.todayTextStyle,
       yearTextStyle: yearTextStyle ?? this.yearTextStyle,
@@ -248,6 +255,7 @@ class CalendarDatePicker2WithActionButtonsConfig
     TextStyle? dayTextStyle,
     TextStyle? selectedDayTextStyle,
     Color? selectedDayHighlightColor,
+    double? selectedDayHighlightOpacity,
     TextStyle? disabledDayTextStyle,
     TextStyle? todayTextStyle,
     TextStyle? yearTextStyle,
@@ -287,6 +295,7 @@ class CalendarDatePicker2WithActionButtonsConfig
           dayTextStyle: dayTextStyle,
           selectedDayTextStyle: selectedDayTextStyle,
           selectedDayHighlightColor: selectedDayHighlightColor,
+          selectedDayHighlightOpacity: selectedDayHighlightOpacity,
           disabledDayTextStyle: disabledDayTextStyle,
           todayTextStyle: todayTextStyle,
           yearTextStyle: yearTextStyle,
@@ -347,6 +356,7 @@ class CalendarDatePicker2WithActionButtonsConfig
     TextStyle? dayTextStyle,
     TextStyle? selectedDayTextStyle,
     Color? selectedDayHighlightColor,
+    double? selectedDayHighlightOpacity,
     TextStyle? disabledDayTextStyle,
     TextStyle? todayTextStyle,
     TextStyle? yearTextStyle,
@@ -389,6 +399,8 @@ class CalendarDatePicker2WithActionButtonsConfig
       selectedDayTextStyle: selectedDayTextStyle ?? this.selectedDayTextStyle,
       selectedDayHighlightColor:
           selectedDayHighlightColor ?? this.selectedDayHighlightColor,
+      selectedDayHighlightOpacity:
+          selectedDayHighlightOpacity ?? this.selectedDayHighlightOpacity,
       disabledDayTextStyle: disabledDayTextStyle ?? this.disabledDayTextStyle,
       todayTextStyle: todayTextStyle ?? this.todayTextStyle,
       yearTextStyle: yearTextStyle ?? this.yearTextStyle,

--- a/lib/src/widgets/calendar_date_picker2.dart
+++ b/lib/src/widgets/calendar_date_picker2.dart
@@ -1089,10 +1089,10 @@ class _DayPickerState extends State<_DayPicker> {
 
             if (isDateInRange && !isStartDateSameToEndDate) {
               final rangePickerIncludedDayDecoration = BoxDecoration(
-                color: (widget.config.selectedDayHighlightColor ??
-                        selectedDayBackground)
-                    .withOpacity(
-                        widget.config.selectedDayHighlightOpacity ?? 0.15),
+                color: widget.config.selectedRangeHighlightColor ??
+                    (widget.config.selectedDayHighlightColor ??
+                            selectedDayBackground)
+                        .withOpacity(0.15),
               );
 
               if (DateUtils.isSameDay(startDate, dayToBuild)) {

--- a/lib/src/widgets/calendar_date_picker2.dart
+++ b/lib/src/widgets/calendar_date_picker2.dart
@@ -1091,7 +1091,8 @@ class _DayPickerState extends State<_DayPicker> {
               final rangePickerIncludedDayDecoration = BoxDecoration(
                 color: (widget.config.selectedDayHighlightColor ??
                         selectedDayBackground)
-                    .withOpacity(0.15),
+                    .withOpacity(
+                        widget.config.selectedDayHighlightOpacity ?? 0.15),
               );
 
               if (DateUtils.isSameDay(startDate, dayToBuild)) {


### PR DESCRIPTION
I am using this Calendar picker with highlight color as Colors.teal[200]. So using 0.15 opacity for range making it difficult to view. So I added support for configuring the opacity.