### PR TITLE
Same date selection today disabled border

### DIFF
--- a/lib/src/widgets/_impl/_day_picker.dart
+++ b/lib/src/widgets/_impl/_day_picker.dart
@@ -165,12 +165,12 @@ class _DayPickerState extends State<_DayPicker> {
                 ? BoxShape.rectangle
                 : BoxShape.circle,
           );
-        } else if (isDisabled) {
-          dayColor = disabledDayColor;
         } else if (isToday) {
           // The current day gets a different text color and a circle stroke
           // border.
-          dayColor = widget.config.selectedDayHighlightColor ?? todayColor;
+          dayColor = isDisabled
+              ? disabledDayColor
+              : widget.config.selectedDayHighlightColor ?? todayColor;
           decoration = BoxDecoration(
             borderRadius: widget.config.dayBorderRadius,
             border: Border.all(color: dayColor),
@@ -178,6 +178,8 @@ class _DayPickerState extends State<_DayPicker> {
                 ? BoxShape.rectangle
                 : BoxShape.circle,
           );
+        } else if (isDisabled) {
+          dayColor = disabledDayColor;
         }
 
         var customDayTextStyle =

--- a/lib/src/widgets/calendar_date_picker2.dart
+++ b/lib/src/widgets/calendar_date_picker2.dart
@@ -40,6 +40,7 @@ class CalendarDatePicker2 extends StatefulWidget {
     this.onValueChanged,
     this.displayedMonthDate,
     this.onDisplayedMonthChanged,
+    this.allowSameDateSelection = false,
     Key? key,
   }) : super(key: key) {
     const valid = true;
@@ -79,6 +80,9 @@ class CalendarDatePicker2 extends StatefulWidget {
 
   /// Called when the displayed month changed
   final ValueChanged<DateTime>? onDisplayedMonthChanged;
+
+  /// Whether allow same date selection
+  final bool allowSameDateSelection;
 
   @override
   State<CalendarDatePicker2> createState() => _CalendarDatePicker2State();
@@ -282,7 +286,7 @@ class _CalendarDatePicker2State extends State<CalendarDatePicker2> {
           widget.config.calendarType != CalendarDatePicker2Type.single ||
               !DateUtils.isSameDay(selectedDates[0],
                   _selectedDates.isNotEmpty ? _selectedDates[0] : null);
-      if (isValueDifferent) {
+      if (isValueDifferent || widget.allowSameDateSelection) {
         _selectedDates = [...selectedDates];
         widget.onValueChanged?.call(_selectedDates);
       }


### PR DESCRIPTION
There are two purposes for this PR:

1. Allow same date selection: Very specific case in which you open the calendar and even though there is an initial selected date you need the user to click on it manually.
2. Allow today date to be decorated (circle border) when it's disabled (the flutter calendarDatePicker has this feature by default).

<img width="375" alt="image" src="https://github.com/theideasaler/calendar_date_picker2/assets/151790256/300d0c3d-5312-48a6-ab90-0ec1afc9e7bb">

