### PR TITLE
feat: allow selecting months and year using finestMode

### DIFF
--- a/lib/src/models/calendar_date_picker2_config.dart
+++ b/lib/src/models/calendar_date_picker2_config.dart
@@ -164,12 +164,17 @@ class CalendarDatePicker2Config {
     this.scrollViewOnScrolling,
     this.scrollViewController,
     this.dynamicCalendarRows,
+    CalendarDatePicker2Mode finestMode = CalendarDatePicker2Mode.day,
   })  : calendarType = calendarType ?? CalendarDatePicker2Type.single,
         firstDate = DateUtils.dateOnly(firstDate ?? DateTime(1970)),
         lastDate =
             DateUtils.dateOnly(lastDate ?? DateTime(DateTime.now().year + 50)),
         currentDate = currentDate ?? DateUtils.dateOnly(DateTime.now()),
-        calendarViewMode = calendarViewMode ?? CalendarDatePicker2Mode.day;
+        finestMode = (finestMode == CalendarDatePicker2Mode.scroll ||
+                calendarType != CalendarDatePicker2Type.single)
+            ? CalendarDatePicker2Mode.day
+            : finestMode,
+        calendarViewMode = calendarViewMode ?? finestMode;
 
   /// The enabled date picker mode
   final CalendarDatePicker2Type calendarType;
@@ -363,6 +368,15 @@ class CalendarDatePicker2Config {
   /// This will make calendar height dynamic to fit real month rows
   final bool? dynamicCalendarRows;
 
+  /// The finest Mode that can be selected
+  ///
+  /// This only takes effect when [calendarType] is [CalendarDatePicker2Type.single]
+  /// When this is [CalendarDatePicker2Mode.scroll] it takes no effect
+  ///
+  /// If it is [CalendarDatePicker2Mode.month] users can only select years and months. Returning always the First Day of that month
+  /// If it is [CalendarDatePicker2Mode.year] users can only select years. Returning always the First Day of that year
+  final CalendarDatePicker2Mode finestMode;
+
   /// Copy the current [CalendarDatePicker2Config] with some new values
   CalendarDatePicker2Config copyWith({
     CalendarDatePicker2Type? calendarType,
@@ -426,6 +440,7 @@ class CalendarDatePicker2Config {
     CalendarScrollViewOnScrolling? scrollViewOnScrolling,
     ScrollController? scrollViewController,
     bool? dynamicCalendarRows,
+    CalendarDatePicker2Mode? finestMode,
   }) {
     return CalendarDatePicker2Config(
       calendarType: calendarType ?? this.calendarType,
@@ -514,6 +529,7 @@ class CalendarDatePicker2Config {
           scrollViewOnScrolling ?? this.scrollViewOnScrolling,
       scrollViewController: scrollViewController ?? this.scrollViewController,
       dynamicCalendarRows: dynamicCalendarRows ?? this.dynamicCalendarRows,
+      finestMode: finestMode ?? this.finestMode,
     );
   }
 }
@@ -583,6 +599,7 @@ class CalendarDatePicker2WithActionButtonsConfig
     CalendarScrollViewOnScrolling? scrollViewOnScrolling,
     ScrollController? scrollViewController,
     bool? dynamicCalendarRows,
+    CalendarDatePicker2Mode finestMode = CalendarDatePicker2Mode.day,
     this.gapBetweenCalendarAndButtons,
     this.cancelButtonTextStyle,
     this.cancelButton,
@@ -654,6 +671,7 @@ class CalendarDatePicker2WithActionButtonsConfig
           scrollViewOnScrolling: scrollViewOnScrolling,
           scrollViewController: scrollViewController,
           dynamicCalendarRows: dynamicCalendarRows,
+          finestMode: finestMode,
         );
 
   /// The gap between calendar and action buttons
@@ -755,6 +773,7 @@ class CalendarDatePicker2WithActionButtonsConfig
     CalendarScrollViewOnScrolling? scrollViewOnScrolling,
     ScrollController? scrollViewController,
     bool? dynamicCalendarRows,
+    CalendarDatePicker2Mode? finestMode,
   }) {
     return CalendarDatePicker2WithActionButtonsConfig(
       calendarType: calendarType ?? this.calendarType,
@@ -856,6 +875,7 @@ class CalendarDatePicker2WithActionButtonsConfig
           scrollViewOnScrolling ?? this.scrollViewOnScrolling,
       scrollViewController: scrollViewController ?? this.scrollViewController,
       dynamicCalendarRows: dynamicCalendarRows ?? this.dynamicCalendarRows,
+      finestMode: finestMode ?? this.finestMode,
     );
   }
 }

--- a/lib/src/widgets/_impl/_date_picker_mode_toggle_button.dart
+++ b/lib/src/widgets/_impl/_date_picker_mode_toggle_button.dart
@@ -155,7 +155,9 @@ class _DatePickerModeToggleButtonState
                 child: SizedBox(
                   height: (widget.config.controlsHeight ?? _subHeaderHeight),
                   child: InkWell(
-                    onTap: widget.config.disableModePicker == true
+                    onTap: widget.config.disableModePicker == true ||
+                            widget.config.finestMode ==
+                                CalendarDatePicker2Mode.year
                         ? null
                         : widget.onYearPressed,
                     child: widget.config.modePickerBuilder
@@ -176,7 +178,9 @@ class _DatePickerModeToggleButtonState
                                   style: controlTextStyle,
                                 ),
                               ),
-                              widget.config.disableModePicker == true
+                              widget.config.disableModePicker == true ||
+                                      widget.config.finestMode ==
+                                          CalendarDatePicker2Mode.year
                                   ? const SizedBox()
                                   : RotationTransition(
                                       turns: _yearController,
@@ -197,57 +201,74 @@ class _DatePickerModeToggleButtonState
                     ? MainAxisAlignment.center
                     : MainAxisAlignment.start,
                 children: [
-                  Semantics(
-                    label: MaterialLocalizations.of(context)
-                        .selectYearSemanticsLabel,
-                    excludeSemantics: true,
-                    button: true,
-                    child: SizedBox(
-                      height:
-                          (widget.config.controlsHeight ?? _subHeaderHeight),
-                      child: InkWell(
-                        onTap: widget.config.disableModePicker == true
-                            ? null
-                            : widget.onMonthPressed,
-                        child: widget.config.modePickerBuilder?.call(
-                              monthDate: widget.monthDate,
-                              isMonthPicker: true,
-                            ) ??
-                            Padding(
-                              padding: EdgeInsets.symmetric(
-                                  horizontal: horizontalPadding),
-                              child: Row(
-                                mainAxisAlignment: modePickerMainAxisAlignment,
-                                children: <Widget>[
-                                  Text(
-                                    widget.config.modePickerTextHandler?.call(
-                                          monthDate: widget.monthDate,
-                                          isMonthPicker: true,
-                                        ) ??
-                                        (widget.config.useAbbrLabelForMonthModePicker ==
-                                                        true
-                                                    ? getLocaleShortMonthFormat
-                                                    : getLocaleFullMonthFormat)(
-                                                _locale)
-                                            .format(widget.monthDate),
-                                    overflow: TextOverflow.ellipsis,
-                                    style: controlTextStyle,
-                                  ),
-                                  widget.config.disableModePicker == true
-                                      ? const SizedBox()
-                                      : RotationTransition(
-                                          turns: _monthController,
-                                          child: modePickerIcon,
-                                        ),
-                                ],
+                  if (widget.config.finestMode !=
+                          CalendarDatePicker2Mode.year &&
+                      widget.config.finestMode !=
+                          CalendarDatePicker2Mode.month) ...[
+                    Semantics(
+                      label: MaterialLocalizations.of(context)
+                          .selectYearSemanticsLabel,
+                      excludeSemantics: true,
+                      button: true,
+                      child: SizedBox(
+                        height:
+                            (widget.config.controlsHeight ?? _subHeaderHeight),
+                        child: InkWell(
+                          onTap: widget.config.disableModePicker == true ||
+                                  (widget.config.finestMode ==
+                                          CalendarDatePicker2Mode.month ||
+                                      widget.config.finestMode ==
+                                          CalendarDatePicker2Mode.year)
+                              ? null
+                              : widget.onMonthPressed,
+                          child: widget.config.modePickerBuilder?.call(
+                                monthDate: widget.monthDate,
+                                isMonthPicker: true,
+                              ) ??
+                              Padding(
+                                padding: EdgeInsets.symmetric(
+                                    horizontal: horizontalPadding),
+                                child: Row(
+                                  mainAxisAlignment:
+                                      modePickerMainAxisAlignment,
+                                  children: <Widget>[
+                                    Text(
+                                      widget.config.modePickerTextHandler?.call(
+                                            monthDate: widget.monthDate,
+                                            isMonthPicker: true,
+                                          ) ??
+                                          (widget.config.useAbbrLabelForMonthModePicker ==
+                                                          true
+                                                      ? getLocaleShortMonthFormat
+                                                      : getLocaleFullMonthFormat)(
+                                                  _locale)
+                                              .format(widget.monthDate),
+                                      overflow: TextOverflow.ellipsis,
+                                      style: controlTextStyle,
+                                    ),
+                                    widget.config.disableModePicker == true ||
+                                            (widget.config.finestMode ==
+                                                    CalendarDatePicker2Mode
+                                                        .month ||
+                                                widget.config.finestMode ==
+                                                    CalendarDatePicker2Mode
+                                                        .year)
+                                        ? const SizedBox()
+                                        : RotationTransition(
+                                            turns: _monthController,
+                                            child: modePickerIcon,
+                                          ),
+                                  ],
+                                ),
                               ),
-                            ),
+                        ),
                       ),
                     ),
-                  ),
-                  SizedBox(
-                    width: widget.config.centerAlignModePicker == true ? 15 : 5,
-                  ),
+                    SizedBox(
+                      width:
+                          widget.config.centerAlignModePicker == true ? 15 : 5,
+                    ),
+                  ],
                   Semantics(
                     label: MaterialLocalizations.of(context)
                         .selectYearSemanticsLabel,
@@ -257,7 +278,9 @@ class _DatePickerModeToggleButtonState
                       height:
                           (widget.config.controlsHeight ?? _subHeaderHeight),
                       child: InkWell(
-                        onTap: widget.config.disableModePicker == true
+                        onTap: widget.config.disableModePicker == true ||
+                                widget.config.finestMode ==
+                                    CalendarDatePicker2Mode.year
                             ? null
                             : widget.onYearPressed,
                         child: widget.config.modePickerBuilder
@@ -276,7 +299,9 @@ class _DatePickerModeToggleButtonState
                                     overflow: TextOverflow.ellipsis,
                                     style: controlTextStyle,
                                   ),
-                                  widget.config.disableModePicker == true
+                                  widget.config.disableModePicker == true ||
+                                          widget.config.finestMode ==
+                                              CalendarDatePicker2Mode.year
                                       ? const SizedBox()
                                       : RotationTransition(
                                           turns: _yearController,

--- a/lib/src/widgets/calendar_date_picker2.dart
+++ b/lib/src/widgets/calendar_date_picker2.dart
@@ -225,6 +225,11 @@ class _CalendarDatePicker2State extends State<CalendarDatePicker2> {
   }
 
   void _handleMonthChanged(DateTime value) {
+    if (widget.config.finestMode == CalendarDatePicker2Mode.month ||
+        widget.config.finestMode == CalendarDatePicker2Mode.year) {
+      _handleDayChanged(value);
+      return;
+    }
     _vibrate();
     setState(() {
       _mode = CalendarDatePicker2Mode.day;
@@ -233,6 +238,10 @@ class _CalendarDatePicker2State extends State<CalendarDatePicker2> {
   }
 
   void _handleYearChanged(DateTime value) {
+    if (widget.config.finestMode == CalendarDatePicker2Mode.year) {
+      _handleDayChanged(value);
+      return;
+    }
     _vibrate();
 
     if (value.isBefore(widget.config.firstDate)) {
@@ -242,7 +251,9 @@ class _CalendarDatePicker2State extends State<CalendarDatePicker2> {
     }
 
     setState(() {
-      _mode = CalendarDatePicker2Mode.day;
+      _mode = widget.config.finestMode == CalendarDatePicker2Mode.scroll
+          ? CalendarDatePicker2Mode.day
+          : widget.config.finestMode;
       _handleDisplayedMonthDateChanged(value, fromYearPicker: true);
     });
   }
@@ -396,7 +407,10 @@ class _CalendarDatePicker2State extends State<CalendarDatePicker2> {
                   } else {
                     _handleModeChanged(
                       _mode == CalendarDatePicker2Mode.month
-                          ? CalendarDatePicker2Mode.day
+                          ? widget.config.finestMode ==
+                                  CalendarDatePicker2Mode.scroll
+                              ? CalendarDatePicker2Mode.day
+                              : widget.config.finestMode
                           : CalendarDatePicker2Mode.month,
                     );
                   }
@@ -407,7 +421,10 @@ class _CalendarDatePicker2State extends State<CalendarDatePicker2> {
                   } else {
                     _handleModeChanged(
                       _mode == CalendarDatePicker2Mode.year
-                          ? CalendarDatePicker2Mode.day
+                          ? widget.config.finestMode ==
+                                  CalendarDatePicker2Mode.scroll
+                              ? CalendarDatePicker2Mode.day
+                              : widget.config.finestMode
                           : CalendarDatePicker2Mode.year,
                     );
                   }


### PR DESCRIPTION
Closes #204 

Allow to set a `finestMode` that allows picking Months/Years

If the Type/Mode is disallowing it this variant takes no affect.