### PR TITLE
fix: pixelate divider in month grid

### DIFF
--- a/lib/src/widgets/_impl/_day_picker.dart
+++ b/lib/src/widgets/_impl/_day_picker.dart
@@ -257,6 +257,16 @@ class _DayPickerState extends State<_DayPicker> {
                 (widget.config.selectedDayHighlightColor ??
                         selectedDayBackground)
                     .withOpacity(0.15),
+            boxShadow: [
+              BoxShadow(
+                blurRadius: 0, // No blur for sharp shadow
+                color: widget.config.selectedRangeHighlightColor ??
+                    (widget.config.selectedDayHighlightColor ??
+                            selectedDayBackground)
+                        .withOpacity(0.15), // Shadow color (same as background)
+                offset: Offset(1, 0), // Shadow offset (1px right)
+              ),
+            ],
           );
 
           if (DateUtils.isSameDay(


### PR DESCRIPTION
**Issue:**

When selecting a start and end date in the range date picker, the range dates are visually separated by vertical dividers. This behavior is demonstrated in the following video:
https://github.com/user-attachments/assets/a5291a03-cb99-4485-8cc2-9c88c7813dfa

**Proposed Solution:**

To fix this issue, I have used the BoxShadow() feature within the _day_picker.dart file. Implementing this change will resolve the problem. The solution is illustrated in the following video:
https://github.com/user-attachments/assets/86e02420-faac-4efa-9fc9-63eaf4b0139e

**Additional Reference:**

For more details, please also refer to the related GitHub issue:
https://github.com/theideasaler/calendar_date_picker2/issues/109


